### PR TITLE
Compiler Improvements for PR #2465

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -64,22 +64,14 @@ Get-ChildItem "$workingdir\functions" -Recurse -File | ForEach-Object {
     }
 Update-Progress "Adding: Config *.json" 40
 Get-ChildItem "$workingdir\config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-Object {
-
     $json = (Get-Content $psitem.FullName).replace("'","''")
-
-    # Make an Array List containing every name at first level of Json File
     $jsonAsObject = $json | convertfrom-json
-    $firstLevelJsonList = [System.Collections.ArrayList]::new()
-    $jsonAsObject.PSObject.Properties.Name | ForEach-Object {$null = $firstLevelJsonList.Add($_)}
 
     # Add 'WPFInstall' as a prefix to every entry-name in 'applications.json' file
     if ($psitem.Name -eq "applications.json") {
-        for ($i = 0; $i -lt $firstLevelJsonList.Count; $i += 1) {
-            $appEntryName = $firstLevelJsonList[$i]
+        foreach ($appEntryName in $jsonAsObject.PSObject.Properties.Name) {
             $appEntryContent = $jsonAsObject.$appEntryName
-            # Remove the entire app entry, so we could add it later with a different name
             $jsonAsObject.PSObject.Properties.Remove($appEntryName)
-            # Add the app entry, but with a different name (WPFInstall + The App Entry Name)
             $jsonAsObject | Add-Member -MemberType NoteProperty -Name "WPFInstall$appEntryName" -Value $appEntryContent
         }
     }

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -67,26 +67,10 @@ Get-ChildItem "$workingdir\config" | Where-Object {$psitem.extension -eq ".json"
 
     $json = (Get-Content $psitem.FullName).replace("'","''")
 
-    # Replace every XML Special Character so it'll render correctly in final build
-    # Only do so if json files has content to be displayed (for example the applications, tweaks, features json files)
-        # Make an Array List containing every name at first level of Json File
-        $jsonAsObject = $json | convertfrom-json
-        $firstLevelJsonList = [System.Collections.ArrayList]::new()
-        $jsonAsObject.PSObject.Properties.Name | ForEach-Object {$null = $firstLevelJsonList.Add($_)}
-        # Note:
-        #  Avoid using HTML Entity Codes, for example '&rdquo;' (stands for "Right Double Quotation Mark"),
-        #  Use **HTML decimal/hex codes instead**, as using HTML Entity Codes will result in XML parse Error when running the compiled script.
-        for ($i = 0; $i -lt $firstLevelJsonList.Count; $i += 1) {
-            $firstLevelName = $firstLevelJsonList[$i]
-            if ($jsonAsObject.$firstLevelName.content -ne $null) {
-                $jsonAsObject.$firstLevelName.content = $jsonAsObject.$firstLevelName.content.replace('&','&#38;').replace('“','&#8220;').replace('”','&#8221;').replace("'",'&#39;').replace('<','&#60;').replace('>','&#62;').replace('—','&#8212;')
-                $jsonAsObject.$firstLevelName.content = $jsonAsObject.$firstLevelName.content.replace('&#39;&#39;',"&#39;") # resolves the Double Apostrophe caused by the first replace function in the main loop
-            }
-            if ($jsonAsObject.$firstLevelName.description -ne $null) {
-                $jsonAsObject.$firstLevelName.description = $jsonAsObject.$firstLevelName.description.replace('&','&#38;').replace('“','&#8220;').replace('”','&#8221;').replace("'",'&#39;').replace('<','&#60;').replace('>','&#62;').replace('—','&#8212;')
-                $jsonAsObject.$firstLevelName.description = $jsonAsObject.$firstLevelName.description.replace('&#39;&#39;',"&#39;") # resolves the Double Apostrophe caused by the first replace function in the main loop
-            }
-        }
+    # Make an Array List containing every name at first level of Json File
+    $jsonAsObject = $json | convertfrom-json
+    $firstLevelJsonList = [System.Collections.ArrayList]::new()
+    $jsonAsObject.PSObject.Properties.Name | ForEach-Object {$null = $firstLevelJsonList.Add($_)}
 
     # Add 'WPFInstall' as a prefix to every entry-name in 'applications.json' file
     if ($psitem.Name -eq "applications.json") {


### PR DESCRIPTION
## Type of Change
- [x] Refactoring
- [x] Hotfix

## Description
- Removes un-needed Special Character Escaping part in Json Parsing of `Compile.ps1` Script. ( commit 46564a3a2b58f222b01d8e3c598d3e573afbbe14 )
- Simplifies the Json Parsing of `Compile.ps1` Script - Thanks again @fam007e . ( commit 88b3d2a9736ac1f652fafa5b73d8ac30f05cb86b )

## Testing
Tested it by running WinUtil & checking different checkboxes tooltips (descriptions) and content (title), in both the tweaks & apps sections. Everything looks good on my end.

## Impact
Makes compiling faster, as it'll need to do less work.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
