### PR TITLE
Disable the 'Scan for Updates' Button when the task is running

### DIFF
--- a/functions/public/Invoke-WPFUpdatesScan.ps1
+++ b/functions/public/Invoke-WPFUpdatesScan.ps1
@@ -1,7 +1,6 @@
 function Invoke-WPFUpdatesScan {
-
-
     Invoke-WPFRunspace -DebugPreference $DebugPreference -ScriptBlock {
+        $sync.form.Dispatcher.Invoke([action] { $sync["WPFScanUpdates"].IsEnabled = $false })
         # Check if the PSWindowsUpdate module is installed
         if (-not (Get-Module -ListAvailable -Name PSWindowsUpdate)) {
             try {
@@ -11,6 +10,7 @@ function Invoke-WPFUpdatesScan {
             }
             catch {
                 Write-Error "Failed to install PSWindowsUpdate module: $_"
+                $sync.form.Dispatcher.Invoke([action] { $sync["WPFScanUpdates"].IsEnabled = $true })
                 return
             }
         }
@@ -22,6 +22,7 @@ function Invoke-WPFUpdatesScan {
         }
         catch {
             Write-Error "Failed to import PSWindowsUpdate module: $_"
+            $sync.form.Dispatcher.Invoke([action] { $sync["WPFScanUpdates"].IsEnabled = $true })
             return
         }
 
@@ -54,5 +55,6 @@ function Invoke-WPFUpdatesScan {
         } catch {
             Write-Error "Error scanning for updates: $_"
         }
+        $sync.form.Dispatcher.Invoke([action] { $sync["WPFScanUpdates"].IsEnabled = $true })
     }
 }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Description
Prior to these changes, user can click the "Scan for Updates" button, and it would cause weird behaviors. Now the user is unable to click the button more then once until the scanning finishes (regardless of the result being successful or not).

## Testing
Tested it multiple times, works as intended.

## Additional Information
Please note the solution being presented isn't the best solution.. but it works. Couldn't find an elegant solution that would fix this bug in least amount of lines as possible.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
